### PR TITLE
Remove unnecessary flags and apply suggestions from rustfmt & clippy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,13 +109,10 @@ fn check_rust_version() {
 }
 
 fn build_elf(args: std::iter::Skip<env::Args>) {
-    let rustflags = env::var("RUSTFLAGS").unwrap_or("".into())
-    + "-C default-linker-libraries -Clink-arg=-z -Clink-arg=muldefs -Clink-arg=-D__3DS__";
+    let rustflags = env::var("RUSTFLAGS").unwrap_or_default();
 
     let mut process = Command::new("cargo")
         .arg("build")
-        .arg("-Z")
-        .arg("unstable-options")
         .arg("-Z")
         .arg("build-std")
         .arg("--target")

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,16 +141,14 @@ fn get_metadata() -> CTRConfig {
 
     let root_crate = metadata.root_package().expect("No root crate found");
 
-    let icon = String::from("./icon.png");
+    let mut icon = String::from("./icon.png");
 
-    let icon = if !Path::new(&icon).exists() {
-        format!(
+    if !Path::new(&icon).exists() {
+        icon = format!(
             "{}/libctru/default_icon.png",
             env::var("DEVKITPRO").unwrap()
         )
-    } else {
-        icon
-    };
+    }
 
     CTRConfig {
         name: root_crate.name.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,6 @@ fn check_rust_version() {
 }
 
 fn build_elf(args: std::iter::Skip<env::Args>) {
-    let rustflags = env::var("RUSTFLAGS").unwrap_or_default();
-
     let mut process = Command::new("cargo")
         .arg("build")
         .arg("-Z")
@@ -120,7 +118,6 @@ fn build_elf(args: std::iter::Skip<env::Args>) {
         .arg("--target")
         .arg("armv6k-nintendo-3ds")
         .args(args)
-        .env("RUSTFLAGS", rustflags)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
See commits for details.

This requires https://github.com/Meziu/rust-horizon/pull/3 to get rid of the `-C default-linker-libraries` flag.