### PR TITLE
Allow other Cargo commands (like check and clippy)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let (command, must_link) = match command.as_deref() {
-        Some("link") => ("link", true),
+        Some("link") => ("build", true),
         Some(command) => (command, false),
         None => {
             print_usage(&mut io::stderr());
@@ -81,7 +81,7 @@ fn main() {
     eprintln!("Running Cargo");
     build_elf(command, &args);
 
-    if !["build", "link"].contains(&command) {
+    if command != "build" && !must_link {
         // We only do more work if it's a build or build + 3dslink operation
         return;
     }


### PR DESCRIPTION
This makes it easier to switch between check/clippy and build. Otherwise, unless you use the same exact RUSTFLAGS and parameters, Cargo will throw away the build cache and rebuild everything.