### PR TITLE
Fix romfs error "Cannot open dir"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -284,7 +284,7 @@ fn build_3dsx(config: &CTRConfig) {
 
     // If romfs directory exists, automatically include it
     if Path::new("./romfs").is_dir() {
-        process = process.arg("--romfs=\"./romfs\"");
+        process = process.arg("--romfs=./romfs");
     }
 
     let mut process = process


### PR DESCRIPTION
The parentheses weren't understood by 3dsxtool. Normally they're just a shell thing anyway and aren't needed when we're directly constructing a process's argument array.