### PR TITLE
Add support for `cargo test`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,22 +188,22 @@ fn print_usage(f: &mut impl std::io::Write) {
         "{name}: {description}.
 
 Usage:
-    {invocation} build [--release] [CARGO_OPTS...]
-    {invocation} link [--release] [CARGO_OPTS...]
-    {invocation} test [--release] [CARGO_OPTS...]
+    {invocation} build [CARGO_OPTS...]
+    {invocation} link [CARGO_OPTS...]
+    {invocation} test [CARGO_OPTS...]
     {invocation} <cargo-command> [CARGO_OPTS...]
     {invocation} -h | --help
 
 Commands:
     build           build a 3dsx executable.
     link            build a 3dsx executable and send it to a device with 3dslink.
+    test            build a 3dsx executable from unit/integration tests and send it to a device.
     <cargo-command> execute some other Cargo command with 3ds options configured (ex. check or clippy).
 
 Options:
     -h --help       Show this screen.
-    --release       Build in release mode.
 
-Additional arguments will be passed through to `cargo build`.
+Additional arguments will be passed through to `<cargo-command>`.
 ",
         name = env!("CARGO_BIN_NAME"),
         description = env!("CARGO_PKG_DESCRIPTION"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
     eprintln!("Running Cargo");
     let (status, messages) = cargo_command.build_elf();
     if !status.success() {
-        process::exit(1);
+        process::exit(status.code().unwrap_or(1));
     }
 
     if !cargo_command.should_build_3dsx() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use cargo_metadata::{Message, MetadataCommand};
 use rustc_version::{Channel, Version};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::{
@@ -18,12 +19,12 @@ struct CTRConfig {
 }
 
 impl CTRConfig {
-    fn path_3dsx(&self) -> PathBuf {
-        self.target_path.with_extension("3dsx")
+    fn path_3dsx(&self) -> OsString {
+        self.target_path.with_extension("3dsx").into()
     }
 
-    fn path_smdh(&self) -> PathBuf {
-        self.target_path.with_extension("smdh")
+    fn path_smdh(&self) -> OsString {
+        self.target_path.with_extension("smdh").into()
     }
 }
 
@@ -86,10 +87,10 @@ fn main() {
     eprintln!("Getting metadata");
     let app_conf = get_metadata(&messages);
 
-    eprintln!("Building smdh");
+    eprintln!("Building smdh {:?}", app_conf.path_3dsx());
     build_smdh(&app_conf);
 
-    eprintln!("Building 3dsx");
+    eprintln!("Building 3dsx {:?}", app_conf.path_3dsx());
     build_3dsx(&app_conf);
 
     if cargo_command.should_link {
@@ -302,7 +303,7 @@ fn build_smdh(config: &CTRConfig) {
         .arg(&config.description)
         .arg(&config.author)
         .arg(&config.icon)
-        .arg(&config.path_smdh())
+        .arg(config.path_smdh())
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -320,8 +321,8 @@ fn build_3dsx(config: &CTRConfig) {
     let mut command = Command::new("3dsxtool");
     let mut process = command
         .arg(&config.target_path)
-        .arg(&config.path_3dsx())
-        .arg(format!("--smdh={}", config.path_3dsx().to_str().unwrap()));
+        .arg(config.path_3dsx())
+        .arg(format!("--smdh={}", config.path_smdh().to_string_lossy()));
 
     // If romfs directory exists, automatically include it
     let (romfs_path, is_default_romfs) = get_romfs_path(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use cargo_metadata::{Message, MetadataCommand};
 use rustc_version::{Channel, Version};
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::{
@@ -19,12 +18,12 @@ struct CTRConfig {
 }
 
 impl CTRConfig {
-    fn path_3dsx(&self) -> OsString {
-        self.target_path.with_extension("3dsx").into()
+    fn path_3dsx(&self) -> PathBuf {
+        self.target_path.with_extension("3dsx")
     }
 
-    fn path_smdh(&self) -> OsString {
-        self.target_path.with_extension("smdh").into()
+    fn path_smdh(&self) -> PathBuf {
+        self.target_path.with_extension("smdh")
     }
 }
 
@@ -87,10 +86,10 @@ fn main() {
     eprintln!("Getting metadata");
     let app_conf = get_metadata(&messages);
 
-    eprintln!("Building smdh {:?}", app_conf.path_smdh());
+    eprintln!("Building smdh:{}", app_conf.path_smdh().display());
     build_smdh(&app_conf);
 
-    eprintln!("Building 3dsx {:?}", app_conf.path_3dsx());
+    eprintln!("Building 3dsx: {}", app_conf.path_3dsx().display());
     build_3dsx(&app_conf);
 
     if cargo_command.should_link {
@@ -342,7 +341,7 @@ fn build_3dsx(config: &CTRConfig) {
     let (romfs_path, is_default_romfs) = get_romfs_path(config);
     if romfs_path.is_dir() {
         println!("Adding RomFS from {}", romfs_path.display());
-        process = process.arg(format!("--romfs={}", romfs_path.display()));
+        process = process.arg(format!("--romfs={}", romfs_path.to_string_lossy()));
     } else if !is_default_romfs {
         eprintln!(
             "Could not find configured RomFS dir: {}",
@@ -381,7 +380,7 @@ fn link(config: &CTRConfig) {
     }
 }
 
-/// Read the RomFS path from the Cargo manifest. If it's unset, use the default.
+/// Read the `RomFS` path from the Cargo manifest. If it's unset, use the default.
 /// The returned boolean is true when the default is used.
 fn get_romfs_path(config: &CTRConfig) -> (PathBuf, bool) {
     let manifest_path = &config.cargo_manifest_path;


### PR DESCRIPTION
This change uses `cargo_metadata::Message` and the `--message-format=json-render-diagnostics` flag to Cargo to find the output path of a given executable, and feeds it to `3dsxtool` etc.

Some caveats:
* Building multiple executables will just take the last one and use it for 3dsx build + link
* (related to above) only one package at a time is supported, so you must specify `--lib` or similar when running `cargo 3ds test`. `--package` is required from the top-level directory.
* The 3dsx executable name is just the name of the package, which for unit tests is just the name of the library. The _filename_, however, is something like `${name}-${hash}.3dsx`, where the hash appears to be derived from the package's dependencies.
* `cargo 3ds test --example` doesn't work due to linker errors (same ones addressed by the `ctru::test_runner` module). I didn't test but assume `cargo 3ds test --test` for integration tests would fail the same way

Future enhancements could be to build a `.3dsx` for _each_ executable that was built, and refuse to `link` if multiple were output? 

Another thought I had – should we consider renaming `link` to `run` instead, to make a more typical kind of Cargo experience? In other words, `cargo run`, `cargo test`, Just Work™️ ?

@Meziu @AzureMarker (PS I can't seem to add reviewers to any of my PRs, do either of you know why that is? Seems it would be easier than tagging every time)