### PR TITLE
Allow passthrough when `--message-format` is specified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Cargo wrapper for developing Rust-based Nintendo 3DS homebrew app
 repository = "https://github.com/Meziu/cargo-3ds"
 license = "MIT"
 authors = ["Andrea Ciliberti <meziu210@icloud.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cargo_metadata = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 description = "Cargo wrapper for developing Rust-based Nintendo 3DS homebrew apps"
 repository = "https://github.com/Meziu/cargo-3ds"
 license = "MIT"
-authors = [ "Andrea Ciliberti <meziu210@icloud.com>" ]
+authors = ["Andrea Ciliberti <meziu210@icloud.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.33.1"
-goblin = "0.4.3"
-scroll = "0.10.1"
 cargo_metadata = "0.14.0"
 rustc_version = "0.4.0"
 serde = "1.0.111"
 serde_derive = "1.0.111"
+tee = "0.1.0"
 toml = "0.5.6"


### PR DESCRIPTION
I use rust-analyzer with VSCode and it requires `--message-format=json` when using a nonstandard `cargo check` command.

This change allows me to configure something like 
```json
{
  "rust-analyzer.cargo.target": "armv6k-nintendo-3ds",
  "rust-analyzer.checkOnSave.overrideCommand": [
    "cargo",
    "3ds",
    "check",
    "--message-format=json",
  ]
}
```

to get proper diagnostics from `cargo 3ds check` in the editor.

I think this used to work normally, before I changed to using `Message::parse_stream` and `--message-format=json-render-diagnostics`.

Tested both to verify JSON output is printed:
* `cargo 3ds check --message-format=json`
* `cargo 3ds check --message-format json`

cc @AzureMarker @Meziu 