### PR TITLE
Use optional env var rather than cargo_metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -296,9 +296,14 @@ fn get_metadata(messages: &[Message]) -> CTRConfig {
         _ => artifact.target.name,
     };
 
+    let author = match package.authors.as_slice() {
+        [name, ..] => name.to_owned(),
+        [] => String::from("Unspecified Author"), // as standard with the devkitPRO toolchain
+    };
+
     CTRConfig {
         name,
-        author: package.authors[0].clone(),
+        author,
         description: package
             .description
             .clone()


### PR DESCRIPTION
Closes #16

`cargo_metadata` hasn't been updated yet so, as suggested by the [RFC description](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html), using `CARGO_PKG_AUTHORS` is suggested. Also, as this field looks like it will soon be deprecated, we may have to think about removing it from all of our packages.